### PR TITLE
Handle bulk updating more complex fields

### DIFF
--- a/test/activerecord/bulk_update_test.rb
+++ b/test/activerecord/bulk_update_test.rb
@@ -72,8 +72,14 @@ module ActiveRecord
       describe "when setting a value with a different datatype" do
         # Test with at least 2 records since the values of the first will be explicitly casted.
         before do
-          first = FakeRecord.find_by!(name: "first").tap { |record| record.name = 1234 }
-          second = FakeRecord.find_by!(name: "second").tap { |record| record.name = 5678 }
+          first = FakeRecord.find_by!(name: "first").tap do |record|
+            record.name = 1234
+            record.details = { "asdf" => 3 }
+          end
+          second = FakeRecord.find_by!(name: "second").tap do |record|
+            record.name = 5678
+            record.details = [{ "asdf" => [{ "nested" => 3 }] }]
+          end
           @updates = [first, second]
         end
 

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -12,6 +12,7 @@ ActiveRecord::Migration.create_table(:fake_records, force: true) do |t|
   t.string :name
   t.boolean :active
   t.integer :rank
+  t.jsonb :details
 
   t.timestamps null: true
 end


### PR DESCRIPTION
- Fetch the attributes to update not via the getters of the instance but directly from the attributes Hash, just as AR does.
- Run the values through the AR predicate builder to be able to quote the more complex, Postgresql specific, datatypes like jsonb fields.