### PR TITLE
Fix for touch with updated_at already set

### DIFF
--- a/lib/activerecord-bulk_update/activerecord/bulk_update.rb
+++ b/lib/activerecord-bulk_update/activerecord/bulk_update.rb
@@ -129,9 +129,10 @@ module ActiveRecord
       end
 
       def touch_all
-        current_times = Array.new(model.timestamp_attributes_for_update_in_model.size) { model.current_time_from_proper_timezone }
+        timestamps_to_add = model.timestamp_attributes_for_update_in_model - @updating_attributes.map(&:to_s)
+        current_times = Array.new(timestamps_to_add.size) { model.current_time_from_proper_timezone }
         values.each { |value| value.concat(current_times) }
-        @updating_attributes += model.timestamp_attributes_for_update_in_model
+        @updating_attributes += timestamps_to_add
       end
   end
 end

--- a/test/activerecord/bulk_update_test.rb
+++ b/test/activerecord/bulk_update_test.rb
@@ -56,6 +56,19 @@ module ActiveRecord
             refute_change(-> { fake_records(:first).reload.updated_at }) { update_records }
           end
         end
+
+        describe "when the updated_at is already part of the changes on one of the records" do
+          before do
+            @updated_at = 30.seconds.ago.utc.round(6)
+            first = FakeRecord.find_by!(name: "first").tap { |record| record.updated_at = @updated_at }
+
+            @updates = [first, fake_records(:second)]
+          end
+
+          it "sets the updated_at to the explicitly given value" do
+            assert_change(-> { fake_records(:first).reload.updated_at }, to: @updated_at) { update_records }
+          end
+        end
       end
 
       describe "when updating the primary key" do


### PR DESCRIPTION
If one of the attributes from `timestamp_attributes_for_update_in_model` is already part of the changeset it must not be included a second time since that triggers a PG::AmbiguousColumn exception.