### PR TITLE
Skip updating records without changes

### DIFF
--- a/lib/activerecord-bulk_update/activerecord/bulk_update.rb
+++ b/lib/activerecord-bulk_update/activerecord/bulk_update.rb
@@ -110,11 +110,12 @@ module ActiveRecord
         end.uniq
 
         updates.each do |record|
+          next unless record.has_changes_to_save?
+
           changes = record.attributes.slice(*updating_attributes).map do |name, value|
             # Using the predicate_builder allows for more complex datatypes like jsonb to be casted correctly.
             predicate_builder.build_bind_attribute(arel_table[name].name, value).value_for_database
           end
-          next if changes.empty?
 
           # Taking the current value of the id allows for the updating of the primary_key.
           values << [record.id_in_database, *changes]

--- a/test/support/assert_change.rb
+++ b/test/support/assert_change.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MiniTest::Test
+class Minitest::Test
   def assert_change(test_proc, from: nil, to: nil, by: nil, &block)
     raise ArgumentError, "'from' and 'to' values must differ" if !from.nil? && from == to
 

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -45,7 +45,7 @@ class PhonyRecord < ActiveRecord::Base
   belongs_to :fake_record
 end
 
-class MiniTest::Test
+class Minitest::Test
   include ::ActiveRecord::TestFixtures
 
   self.fixture_path = "test/fixtures"


### PR DESCRIPTION
Currently when given a set of records to update it will update all records in that set if at least one of these records has been updated.

The change in this PR will skip the updates for those records in the set that have no changes. This was always the intended behavior but was not correctly implemented. The `changes` variable is only empty if the `updating_attributes` variable is empty and that can only happen if none of the records in the set have been changed.