### PR TITLE
Add bulk_insert! which does not ignore duplicate records

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Inserts multiple records into the database in a single query and raises an excep
 ```ruby
 users = [User.new(name: "foo"), User.new(name: "bar")]
 
-User.where(active: true).bulk_insert(users, touch: true)
+User.where(active: true).bulk_insert!(users, touch: true)
 ```
 
 | Option            | Default | Description                                                                    |

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ users = [User.new(name: "foo"), User.new(name: "bar")]
 User.where(active: true).bulk_create(users)
 ```
 
-| Option  | Default | Description |
-| ------------- | ------------- | ------------- |
-| validate | true | when true it validates the records. |
-| touch | true | when true it sets the created_at and updated_at timestamps. |
-| ignore_persisted | false | when true it ignores any persisted records, when false it raises an exception. |
+| Option           | Default | Description                                                                    |
+| ---------------- | ------- | ------------------------------------------------------------------------------ |
+| validate         | true    | when true it validates the records.                                            |
+| touch            | true    | when true it sets the created_at and updated_at timestamps.                    |
+| ignore_persisted | false   | when true it ignores any persisted records, when false it raises an exception. |
 
 ### .bulk_create!
 
@@ -51,14 +51,32 @@ Inserts multiple records into the database in a single query.
 ```ruby
 users = [User.new(name: "foo"), User.new(name: "bar")]
 
-User.where(active: true).bulk_insert(users, touch: true)
+User.where(active: true).bulk_insert(users, touch: true, ignore_duplicates: true)
 ```
 
-| Option  | Default | Description |
-| ------------- | ------------- | ------------- |
-| validate | false | when true it validates the records. |
-| touch | false | when true it sets the created_at and updated_at timestamps. |
-| ignore_persisted | false | when true it ignores any persisted records, when false it raises an exception. |
+| Option            | Default | Description                                                                    |
+| ----------------- | ------- | ------------------------------------------------------------------------------ |
+| validate          | false   | when true it validates the records.                                            |
+| touch             | false   | when true it sets the created_at and updated_at timestamps.                    |
+| ignore_persisted  | false   | when true it ignores any persisted records, when false it raises an exception. |
+| ignore_duplicates | true    | when true it ignores any duplicate records, when false it raises an exception. |
+
+### .bulk_insert!
+
+Inserts multiple records into the database in a single query and raises an exception in case of duplicate records.
+
+```ruby
+users = [User.new(name: "foo"), User.new(name: "bar")]
+
+User.where(active: true).bulk_insert(users, touch: true, ignore_duplicates: false)
+```
+
+| Option            | Default | Description                                                                    |
+| ----------------- | ------- | ------------------------------------------------------------------------------ |
+| validate          | false   | when true it validates the records.                                            |
+| touch             | false   | when true it sets the created_at and updated_at timestamps.                    |
+| ignore_persisted  | false   | when true it ignores any persisted records, when false it raises an exception. |
+| ignore_duplicates | false   | when true it ignores any duplicate records, when false it raises an exception. |
 
 #### extras
 
@@ -66,7 +84,7 @@ User.where(active: true).bulk_insert(users, touch: true)
 
 ### .bulk_upsert
 
-Upserts multiple records into the database in a single query, when no unique key is given it will render an error ```ActiveRecord::RecordNotUnique``` if there are any duplicate rows.
+Upserts multiple records into the database in a single query, when no unique key is given it will render an error `ActiveRecord::RecordNotUnique` if there are any duplicate rows.
 
 ```ruby
 users = [User.new(name: "foo"), User.new(name: "bar")]
@@ -74,21 +92,20 @@ users = [User.new(name: "foo"), User.new(name: "bar")]
 User.where(active: true).bulk_upsert(users, touch: true, unique_by: :name)
 ```
 
-| Option  | Default | Description |
-| ------------- | ------------- | ------------- |
-| validate | false | when true it validates the records. |
-| touch | false | when true it sets the created_at and updated_at timestamps. |
-| ignore_persisted | false | when true it ignores any persisted records, when false it raises an exception. |
-| unique_key | nil | when not given it will render an error if there are duplicates |
-
+| Option           | Default | Description                                                                    |
+| ---------------- | ------- | ------------------------------------------------------------------------------ |
+| validate         | false   | when true it validates the records.                                            |
+| touch            | false   | when true it sets the created_at and updated_at timestamps.                    |
+| ignore_persisted | false   | when true it ignores any persisted records, when false it raises an exception. |
+| unique_key       | nil     | when not given it will render an error if there are duplicates                 |
 
 Unique indexes can be identified by columns or name:
+
 ```ruby
 unique_by: :name
 unique_by: %i[ company_id name ]
 unique_by: :index_name_on_company
 ```
-
 
 #### extras
 
@@ -106,10 +123,10 @@ user2.email = "bar@example.com"
 User.where(active: true).bulk_update([user1, user2], validate: false)
 ```
 
-| Option  | Default | Description |
-| ------------- | ------------- | ------------- |
-| validate | true | when true it validates the records. |
-| touch | true | when true it sets the updated_at timestamp. |
+| Option   | Default | Description                                 |
+| -------- | ------- | ------------------------------------------- |
+| validate | true    | when true it validates the records.         |
+| touch    | true    | when true it sets the updated_at timestamp. |
 
 ### .bulk_update!
 
@@ -123,10 +140,10 @@ see: [bulk_update](#bulk_update)
 
 Except the default values for the options are different.
 
-| Option  | Default | Description |
-| ------------- | ------------- | ------------- |
-| validate | false | when true it validates the records. |
-| touch | false | when true it sets the updated_at timestamp. |
+| Option   | Default | Description                                 |
+| -------- | ------- | ------------------------------------------- |
+| validate | false   | when true it validates the records.         |
+| touch    | false   | when true it sets the updated_at timestamp. |
 
 ### .bulk_update_all
 
@@ -140,9 +157,9 @@ changes = {
 User.where(active: true).bulk_update_all(changes)
 ```
 
-| Option  | Default | Description |
-| ------------- | ------------- | ------------- |
-| touch | false | when true it sets the updated_at timestamp. |
+| Option | Default | Description                                 |
+| ------ | ------- | ------------------------------------------- |
+| touch  | false   | when true it sets the updated_at timestamp. |
 
 ### .bulk_valid?
 
@@ -159,7 +176,9 @@ Returns an Array of Hashes containing the error details of the invalid records, 
 It does not return details for valid records. In order to figure out to which record the errors belong the `id` of the record included as well as its index in the given collection.
 
 #### Callbacks
+
 The main difference with the regular ActiveRecord methods is that most callbacks are not triggered on the instances. Only the following callbacks are triggered:
+
 - `before_validation`
 - `after_validation`
 - `before_commit`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Inserts multiple records into the database in a single query.
 ```ruby
 users = [User.new(name: "foo"), User.new(name: "bar")]
 
-User.where(active: true).bulk_insert(users, touch: true, ignore_duplicates: true)
+User.where(active: true).bulk_insert(users, touch: true)
 ```
 
 | Option            | Default | Description                                                                    |
@@ -68,7 +68,7 @@ Inserts multiple records into the database in a single query and raises an excep
 ```ruby
 users = [User.new(name: "foo"), User.new(name: "bar")]
 
-User.where(active: true).bulk_insert(users, touch: true, ignore_duplicates: false)
+User.where(active: true).bulk_insert(users, touch: true)
 ```
 
 | Option            | Default | Description                                                                    |

--- a/lib/activerecord-bulk_update/activerecord/bulk_insert.rb
+++ b/lib/activerecord-bulk_update/activerecord/bulk_insert.rb
@@ -3,13 +3,14 @@
 module ActiveRecord
   # Builds the query to insert multiple records in a single statement.
   class BulkInsert
-    attr_reader :model, :inserts, :values, :ignore_persisted
+    attr_reader :model, :inserts, :values, :ignore_persisted, :ignore_duplicates
 
-    def initialize(model, inserts, ignore_persisted:)
+    def initialize(model, inserts, ignore_persisted:, ignore_duplicates:)
       @model = model
       @inserts = inserts
       @values = []
       @ignore_persisted = ignore_persisted
+      @ignore_duplicates = ignore_duplicates
     end
 
     def insert_records
@@ -34,7 +35,11 @@ module ActiveRecord
 
     private
       def execute
-        model.insert_all!(values, returning: returning_attributes)
+        if ignore_duplicates
+          model.insert_all(values, returning: returning_attributes)
+        else
+          model.insert_all!(values, returning: returning_attributes)
+        end
       end
 
       def inserting_attributes

--- a/lib/activerecord-bulk_update/activerecord/relation.rb
+++ b/lib/activerecord-bulk_update/activerecord/relation.rb
@@ -26,8 +26,12 @@ module ActiveRecord
       BulkDelete.new(self, deletes).delete_by_filters
     end
 
-    def bulk_insert(inserts, ignore_persisted: false)
-      BulkInsert.new(self, inserts, ignore_persisted: ignore_persisted).insert_records
+    def bulk_insert(inserts, ignore_persisted: false, ignore_duplicates: true)
+      BulkInsert.new(self, inserts, ignore_persisted: ignore_persisted, ignore_duplicates: ignore_duplicates).insert_records
+    end
+
+    def bulk_insert!(inserts, ignore_persisted: false, ignore_duplicates: false)
+      BulkInsert.new(self, inserts, ignore_persisted: ignore_persisted, ignore_duplicates: false).insert_records
     end
 
     def bulk_update(*args, **kwargs)

--- a/lib/activerecord-bulk_update/activerecord/relation.rb
+++ b/lib/activerecord-bulk_update/activerecord/relation.rb
@@ -31,7 +31,7 @@ module ActiveRecord
     end
 
     def bulk_insert!(inserts, ignore_persisted: false, ignore_duplicates: false)
-      BulkInsert.new(self, inserts, ignore_persisted: ignore_persisted, ignore_duplicates: false).insert_records
+      BulkInsert.new(self, inserts, ignore_persisted: ignore_persisted, ignore_duplicates: ignore_duplicates).insert_records
     end
 
     def bulk_update(*args, **kwargs)


### PR DESCRIPTION
In deze PR voeren we een aanpassing door aan de `bulk_insert` methode. Momenteel wordt er bij een duplicate record een unique constraint error geraised. In sommige gevallen willen we dat dit stilletjes genegeerd wordt.

Daarom hebben we de implementatie van `bulk_insert` aangepast zodat deze hem stilletjes negeert. Daarnaast hebben we een `bulk_insert!` toegevoegd waarbij er een error wordt geraised in het geval van duplicate records.

Groetjes Mathijs & Vincent

### Voor de reviewer
Ik zal eerst ook nog een PR maken op productie waarbij we de `bulk_insert` vervangen door een `bulk_insert!`.