### PR TITLE
Fix updating by hash when values are the same

### DIFF
--- a/lib/activerecord-bulk_update/activerecord/bulk_update.rb
+++ b/lib/activerecord-bulk_update/activerecord/bulk_update.rb
@@ -61,7 +61,7 @@ module ActiveRecord
         if filter_attributes.one? && update_values.uniq.one?
           attr = filter_attributes.first
           stmt.set(update_attributes.zip(update_values.first).map { |attr, value| [arel_table[attr], value] })
-          arel.where(predicate_builder.build(arel_table[attr], filter_values))
+          arel.where(predicate_builder.build(arel_table[attr], filter_values.flatten))
         else
           stmt.set(update_attributes.map { |attr| [arel_table[attr], source["_#{attr}"]] })
           filter_attributes.each { |attr| arel.where(arel_table[attr].eq(source[attr])) }

--- a/test/activerecord/bulk_update_test.rb
+++ b/test/activerecord/bulk_update_test.rb
@@ -303,6 +303,24 @@ module ActiveRecord
         end
       end
 
+      describe "when all records update to the same value" do
+        # Test with at least 2 records
+        before do
+          @updates = {
+            { name: "first" } => { name: 1234 },
+            { name: "second" } => { name: 1234 }
+          }
+        end
+
+        it "updates the first record" do
+          assert_change(-> { fake_records(:first).reload.name }, to: "1234") { update_by_hash }
+        end
+
+        it "updates the second record" do
+          assert_change(-> { fake_records(:second).reload.name }, to: "1234") { update_by_hash }
+        end
+      end
+
       describe "when assigning values with a different datatype" do
         # Test with at least 2 records since the values of the first will be explicitly casted.
         before do


### PR DESCRIPTION
**Beschrijving:**
In deze PR voegen we een fix voor `update_by_hash` toe voor het geval de waarden dezelfde zijn.

In dit project moet 100% coverage afgedwongen worden. Ik ben er sterk voor om dezelfde test setup te gebruiken als in onze andere projecten. Dat maakt het makkelijker voor andere developers om aan te haken. Ook wordt de CI setup makkelijker te onderhouden.