### PR TITLE
Fix UPDATE with JOIN on Rails 8.1

### DIFF
--- a/lib/activerecord-bulk_update/arel/visitors/postgresql.rb
+++ b/lib/activerecord-bulk_update/arel/visitors/postgresql.rb
@@ -27,9 +27,11 @@ module Arel
       #
       # Mirrors ActiveRecord 8.1's UPDATE-with-JOIN handling (alias the target,
       # move joins into a FROM clause) and additionally emits the optional
-      # `o.from` node used by bulk_update's VALUES-list updates.
+      # `o.from` node used by bulk_update's VALUES-list updates. The gem
+      # supports ActiveRecord > 6, so accessors that only exist on newer
+      # versions (`retryable=`, `comment`) are guarded.
       def visit_Arel_Nodes_UpdateStatement(o, collector)
-        collector.retryable = false
+        collector.retryable = false if collector.respond_to?(:retryable=)
         o = prepare_update_statement(o)
 
         collector << "UPDATE "
@@ -42,13 +44,13 @@ module Arel
         else
           collector = visit o.relation, collector
           collect_nodes_for o.values, collector, " SET "
+          maybe_visit o.from, collector # MONKEY_PATCH
         end
 
-        maybe_visit o.from, collector # MONKEY_PATCH
         collect_nodes_for o.wheres, collector, " WHERE ", " AND "
         collect_nodes_for o.orders, collector, " ORDER BY "
         maybe_visit o.limit, collector
-        maybe_visit o.comment, collector
+        maybe_visit o.comment, collector if o.respond_to?(:comment)
       end
     end
   end

--- a/lib/activerecord-bulk_update/arel/visitors/postgresql.rb
+++ b/lib/activerecord-bulk_update/arel/visitors/postgresql.rb
@@ -25,17 +25,30 @@ module Arel
 
       # MONKEY_PATCH
       #
-      # In order to be able to include the optional FROM statement the existing method needs to be overridden.
+      # Mirrors ActiveRecord 8.1's UPDATE-with-JOIN handling (alias the target,
+      # move joins into a FROM clause) and additionally emits the optional
+      # `o.from` node used by bulk_update's VALUES-list updates.
       def visit_Arel_Nodes_UpdateStatement(o, collector)
+        collector.retryable = false
         o = prepare_update_statement(o)
 
         collector << "UPDATE "
-        collector = visit o.relation, collector
-        collect_nodes_for o.values, collector, " SET "
+
+        if has_join_sources?(o)
+          collector = visit o.relation.left, collector
+          collect_nodes_for o.values, collector, " SET "
+          collector << " FROM "
+          collector = inject_join o.relation.right, collector, " "
+        else
+          collector = visit o.relation, collector
+          collect_nodes_for o.values, collector, " SET "
+        end
+
         maybe_visit o.from, collector # MONKEY_PATCH
         collect_nodes_for o.wheres, collector, " WHERE ", " AND "
         collect_nodes_for o.orders, collector, " ORDER BY "
         maybe_visit o.limit, collector
+        maybe_visit o.comment, collector
       end
     end
   end

--- a/test/arel/visitors/postgresql_test.rb
+++ b/test/arel/visitors/postgresql_test.rb
@@ -41,6 +41,18 @@ module Arel
         end
       end
 
+      describe "#visit_Arel_Nodes_UpdateStatement" do
+        describe "when the relation has join sources" do
+          it "aliases the target table and moves joins into a FROM clause" do
+            relation = FakeRecord.joins(:phony_records).where(phony_records: { name: "first" })
+
+            assert_equal(1, relation.update_all(active: false))
+            assert_equal(false, fake_records(:first).reload.active)
+            assert_equal(true, fake_records(:second).reload.active)
+          end
+        end
+      end
+
       describe "#visit_Arel_Nodes_From" do
         def visit_Arel_Nodes_From
           PostgreSQL


### PR DESCRIPTION
## Summary

- Rails 8.1 ships a new `visit_Arel_Nodes_UpdateStatement` for PostgreSQL: when the relation has joins, it aliases the target table as `__active_record_update_alias`, emits `SET …`, then `FROM table JOIN …`. The gem's override skipped that split and visited the relation as a whole, producing invalid SQL like:

  ```sql
  UPDATE "t" "__active_record_update_alias" "t" INNER JOIN "u" ON … SET … WHERE …
  ```

- This caused `update_all` on any joined relation (e.g. `parent.has_many_through_assoc.update_all(...)`) to fail with `PG::SyntaxError` once the consuming app upgraded to Rails 8.1.

- Fix: mirror Rails 8.1's if/else in the override while still calling `maybe_visit o.from` for bulk_update's VALUES-list updates, and emit `o.comment` to match the upstream signature.

## Test plan

- [x] Added a regression test that calls `update_all` on a relation with `joins(:phony_records)` and verifies only the matching parent is updated.
- [x] `bundle exec rake test` — 149 runs, 252 assertions, 0 failures, 100.00% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)